### PR TITLE
Rename to babel-plugin-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# babel-plugin-antd
+# babel-plugin-import
+
+Component modular import plugin for babel, compatible with [antd](https://github.com/ant-design/ant-design), [antd-mobile](https://github.com/ant-design/ant-design-mobile), and so on.
 
 [![NPM version](https://img.shields.io/npm/v/babel-plugin-antd.svg?style=flat)](https://npmjs.org/package/babel-plugin-antd)
 [![Build Status](https://img.shields.io/travis/ant-design/babel-plugin-antd.svg?style=flat)](https://travis-ci.org/ant-design/babel-plugin-antd)
@@ -37,14 +39,14 @@ ReactDOM.render(<div>
 ## Usage
 
 ```bash
-npm install babel-plugin-antd --save-dev
+npm install babel-plugin-import --save-dev
 ```
 
 Via `.babelrc` or babel-loader.
 
 ```js
 {
-  "plugins": [["antd", options]]
+  "plugins": [["import", options]]
 }
 ```
 
@@ -56,7 +58,8 @@ Via `.babelrc` or babel-loader.
 {
   "style": true,
   "libraryDirectory": "component",  // default: lib
-  "libraryName": "antd"            // default: antd
+  "libraryName": "antd",
+  "camel2DashComponentName": false, // default: true
 }
 ```
 
@@ -82,4 +85,4 @@ For Example:
 
 - `["antd", [{ "libraryName": "antd" }]]`: import js modularly
 - `["antd", [{ "libraryName": "antd", "style": true }]]`: import js and css modularly (less source files)
-- `["antd", [{ "libraryName": "antd", "style": "css" }]]`: import style css modularly (css built files)
+- `["antd", [{ "libraryName": "antd", "style": "css" }]]`: import js and css modularly (css built files)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ Component modular import plugin for babel, compatible with [antd](https://github
 
 ## CHANGELOG
 
+1.0.0
+
+Rename to babel-plugin-import.
+
+- **BREAKCHANGE: ** Don't support `libDir` anymore, replace it with `libraryDirectory`
+- **BREAKCHANGE: ** Remove `libraryName` default value (previous `antd`)
+- [#66](https://github.com/ant-design/babel-plugin-antd/issues/66), Support material-ui
+  - `libraryDirectory` could be empty string
+  - add option `camel2DashComponentName`, default `true`
+- [#67](https://github.com/ant-design/babel-plugin-antd/pull/67), Support ExpressionStatement
+
 0.5.1
 
 - [#50](https://github.com/ant-design/babel-plugin-antd/pull/50) - Support both antd and antd-mobile

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "babel-plugin-antd",
+  "name": "babel-plugin-import",
   "version": "0.5.1",
-  "description": "Modular antd build plugin for babel.",
+  "description": "Component modular import plugin for babel.",
   "main": "lib/index.js",
   "scripts": {
     "build": "rm -rf lib && ./node_modules/.bin/babel src --out-dir lib --ignore __tests__",
@@ -31,6 +31,7 @@
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "expect": "^1.13.4",
+    "material-ui": "^0.15.4",
     "mocha": "^2.3.4",
     "pre-commit": "~1.1.2"
   },

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,11 +1,17 @@
+import { join } from 'path';
 
 export default class Plugin {
-  constructor(libraryName, libraryDirectory, style, types) {
+  constructor(libraryName, libraryDirectory, style, camel2DashComponentName, types) {
     this.specified = null;
     this.libraryObjs = null;
     this.selectedMethods = null;
     this.libraryName = libraryName;
-    this.libraryDirectory = libraryDirectory || 'lib';
+    this.libraryDirectory = typeof libraryDirectory === 'undefined'
+      ? 'lib'
+      : libraryDirectory;
+    this.camel2DashComponentName = typeof camel2DashComponentName === 'undefined'
+      ? true
+      : camel2DashComponentName;
     this.style = style || false;
     this.types = types;
   }
@@ -14,7 +20,10 @@ export default class Plugin {
     if (!this.selectedMethods[methodName]) {
       const libraryDirectory = this.libraryDirectory;
       const style = this.style;
-      const path = `${this.libraryName}/${libraryDirectory}/${camel2Dash(methodName)}`;
+      const transformedMethodName = this.camel2DashComponentName
+        ? camel2Dash(methodName)
+        : methodName;
+      const path = join(this.libraryName, libraryDirectory, transformedMethodName);
       this.selectedMethods[methodName] = file.addImport(path, 'default');
       if (style === true) {
         file.addImport(`${path}/style`);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import Plugin from './Plugin';
 
 export default function ({ types }) {
@@ -17,15 +18,18 @@ export default function ({ types }) {
   }
 
   function Program(path, { opts }) {
+    // Init plugin instances once.
     if (!plugins) {
       if (Array.isArray(opts)) {
-        plugins = opts.map(({ libraryName, libraryDirectory, style }) =>
-          new Plugin(libraryName, libraryDirectory, style, types)
-        );
+        plugins = opts.map(({ libraryName, libraryDirectory, style }) => {
+          assert(libraryName, 'libraryName should be provided');
+          return new Plugin(libraryName, libraryDirectory, style, types);
+        });
       } else {
         opts = opts || {};
+        assert(opts.libraryName, 'libraryName should be provided');
         plugins = [
-          new Plugin(opts.libraryName || 'antd', opts.libraryDirectory || opts.libDir, opts.style, types)
+          new Plugin(opts.libraryName, opts.libraryDirectory, opts.style, types)
         ];
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,15 @@ export default function ({ types }) {
     // Init plugin instances once.
     if (!plugins) {
       if (Array.isArray(opts)) {
-        plugins = opts.map(({ libraryName, libraryDirectory, style }) => {
+        plugins = opts.map(({ libraryName, libraryDirectory, style, camel2DashComponentName }) => {
           assert(libraryName, 'libraryName should be provided');
-          return new Plugin(libraryName, libraryDirectory, style, types);
+          return new Plugin(libraryName, libraryDirectory, style, camel2DashComponentName, types);
         });
       } else {
         opts = opts || {};
         assert(opts.libraryName, 'libraryName should be provided');
         plugins = [
-          new Plugin(opts.libraryName, opts.libraryDirectory, opts.style, types)
+          new Plugin(opts.libraryName, opts.libraryDirectory, opts.style, opts.camel2DashComponentName, types)
         ];
       }
     }

--- a/test/fixtures/material-ui/actual.js
+++ b/test/fixtures/material-ui/actual.js
@@ -1,0 +1,3 @@
+import { Toolbar } from 'material-ui';
+
+Toolbar('xxx');

--- a/test/fixtures/material-ui/expected.js
+++ b/test/fixtures/material-ui/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var _Toolbar = require('material-ui/Toolbar');
+
+var _Toolbar2 = _interopRequireDefault(_Toolbar);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _Toolbar2.default)('xxx');

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -30,6 +30,12 @@ describe('index', () => {
         pluginWithOpts = [
           plugin, { libraryName: 'antd', style: true }
         ];
+      } else if (caseName === 'material-ui') {
+        pluginWithOpts = [
+          plugin, [
+            { libraryName: 'material-ui', libraryDirectory: '', camel2DashComponentName: false },
+          ]
+        ];
       } else if (caseName === 'multiple-libraries') {
         pluginWithOpts = [
           plugin, [

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -28,7 +28,7 @@ describe('index', () => {
       caseName = caseName.replace(/-only$/, '');
       if (caseName === 'import-css') {
         pluginWithOpts = [
-          plugin, { style: true }
+          plugin, { libraryName: 'antd', style: true }
         ];
       } else if (caseName === 'multiple-libraries') {
         pluginWithOpts = [
@@ -36,6 +36,10 @@ describe('index', () => {
             { libraryName: 'antd' },
             { libraryName: 'antd-mobile' },
           ]
+        ];
+      } else {
+        pluginWithOpts = [
+          plugin, { libraryName: 'antd' }
         ];
       }
 


### PR DESCRIPTION
## Tasks

- [x] **BREAKCHANGE：**不再支持 libDir 这个配置，统一用 libraryDirectory
- [x] 移除 libraryName 默认值（之前是 antd)
- #66 
  - [x] libraryDirectory 支持空白字符串
  - [x] camel2DashComponentName，默认 true，允许不对 componentName 做 camel2Dash 的转换
- [x] 更新 README
- [x] 更新 CHANGELOG
- [x] 重命名为 babel-plugin-import

## After Publish

- [ ] 更新 ant-design 文档
- [ ] npm deprecate babel-plugin-antd
